### PR TITLE
Rename docx package to python-docx

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 streamlit==1.36.0
 pdfplumber==0.11.2
-docx==1.1.2
+python-docx==1.1.2
 spacy==3.7.5
 pandas==2.2.2


### PR DESCRIPTION
docx package exists, but it is leads to an issue "ERROR: Could not find a version that satisfies the requirement docx==1.1.2 (from versions: 0.1.2, 0.2.0, 0.2.1, 0.2.2, 0.2.3, 0.2.4)" as there is no docx==1.1.2